### PR TITLE
[LT 4386] Update Account Data after updating ClientProfile

### DIFF
--- a/src/MarginTrading.AccountsManagement/Extensions/DateTimeExtensions.cs
+++ b/src/MarginTrading.AccountsManagement/Extensions/DateTimeExtensions.cs
@@ -2,6 +2,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 
 namespace MarginTrading.AccountsManagement.Extensions
 {
@@ -15,6 +16,38 @@ namespace MarginTrading.AccountsManagement.Extensions
                     return DateTime.SpecifyKind(dateTime, DateTimeKind.Utc);
                 default:
                     return dateTime.ToUniversalTime();
+            }
+        }
+
+        public static DateTime MaxDateTime(DateTime first, DateTime second)
+        {
+            if(Comparer<DateTime>.Default.Compare(first, second) > 0)
+                return first;
+
+            return second;
+        }
+
+        /// <summary>
+        /// Updates each element in given collection in a way that given property is set to greater datetime among two values. 
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="collection"></param>
+        /// <param name="getFirstTimeStamp">The delegate that returns the first DateTime property for comparison</param>
+        /// <param name="getSecondTimestamp">The delegate that returns the second DateTime property for comparison</param>
+        /// <param name="updateProperty">The action that updates desired property with most recent DateTime property.</param>
+        public static void OverwriteTimestampWithMostRecent<T>(IEnumerable<T> collection, 
+            Func<T, DateTime> getFirstTimeStamp,
+            Func<T, DateTime> getSecondTimestamp,
+            Action<T, DateTime> updateProperty)
+        {
+            foreach(var item in collection)
+            {
+                var datetime1 = getFirstTimeStamp(item);
+                var datetime2 = getSecondTimestamp(item);
+
+                var mostRecent = MaxDateTime(datetime1, datetime2);
+
+                updateProperty.Invoke(item, mostRecent);
             }
         }
     }

--- a/src/MarginTrading.AccountsManagement/Repositories/Implementation/SQL/AccountEntity.cs
+++ b/src/MarginTrading.AccountsManagement/Repositories/Implementation/SQL/AccountEntity.cs
@@ -46,5 +46,7 @@ namespace MarginTrading.AccountsManagement.Repositories.Implementation.SQL
 
         AccountAdditionalInfo IAccount.AdditionalInfo => JsonConvert.DeserializeObject<AccountAdditionalInfo>(AdditionalInfo);
         public string AdditionalInfo { get; set; } = "{}";
+
+        public DateTime LastUpdatedAt { get; set; } 
     }
 }

--- a/src/MarginTrading.AccountsManagement/Repositories/Implementation/SQL/ClientEntity.cs
+++ b/src/MarginTrading.AccountsManagement/Repositories/Implementation/SQL/ClientEntity.cs
@@ -1,13 +1,18 @@
-﻿using MarginTrading.AccountsManagement.InternalModels.Interfaces;
+﻿using System;
+
+using MarginTrading.AccountsManagement.InternalModels.Interfaces;
 
 namespace MarginTrading.AccountsManagement.Repositories.Implementation.SQL
 {
     public class ClientEntity : IClient
     {
         public string Id { get; set; }
+
         public string TradingConditionId { get; set; }
         
         public string UserId { get; set; }
+
+        public DateTime LastUpdatedAt { get; set; }
 
         public static ClientEntity From(IAccount account)
         {

--- a/src/MarginTrading.AccountsManagement/Repositories/Implementation/SQL/ClientEntity.cs
+++ b/src/MarginTrading.AccountsManagement/Repositories/Implementation/SQL/ClientEntity.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-
 using MarginTrading.AccountsManagement.InternalModels.Interfaces;
 
 namespace MarginTrading.AccountsManagement.Repositories.Implementation.SQL

--- a/src/MarginTrading.AccountsManagement/Services/Implementation/AccountManagementService.cs
+++ b/src/MarginTrading.AccountsManagement/Services/Implementation/AccountManagementService.cs
@@ -523,7 +523,7 @@ namespace MarginTrading.AccountsManagement.Services.Implementation
 
             foreach (var account in afterUpdate)
             {
-                await _accountsRepository.UpdateAccountAsync(account.Id, false, false);
+                await _accountsRepository.UpdateAccountAsync(account.Id, isDisabled: false, isWithdrawalDisabled: false);
 
                 _eventSender.SendAccountChangedEvent(
                     nameof(UpdateClientTradingCondition),

--- a/src/MarginTrading.AccountsManagement/Services/Implementation/AccountManagementService.cs
+++ b/src/MarginTrading.AccountsManagement/Services/Implementation/AccountManagementService.cs
@@ -523,8 +523,6 @@ namespace MarginTrading.AccountsManagement.Services.Implementation
 
             foreach (var account in afterUpdate)
             {
-                await _accountsRepository.UpdateAccountAsync(account.Id, isDisabled: false, isWithdrawalDisabled: false);
-
                 _eventSender.SendAccountChangedEvent(
                     nameof(UpdateClientTradingCondition),
                     account,

--- a/src/MarginTrading.AccountsManagement/Services/Implementation/AccountManagementService.cs
+++ b/src/MarginTrading.AccountsManagement/Services/Implementation/AccountManagementService.cs
@@ -523,6 +523,8 @@ namespace MarginTrading.AccountsManagement.Services.Implementation
 
             foreach (var account in afterUpdate)
             {
+                await _accountsRepository.UpdateAccountAsync(account.Id, false, false);
+
                 _eventSender.SendAccountChangedEvent(
                     nameof(UpdateClientTradingCondition),
                     account,

--- a/src/MarginTrading.AccountsManagement/Services/Implementation/EventSender.cs
+++ b/src/MarginTrading.AccountsManagement/Services/Implementation/EventSender.cs
@@ -4,6 +4,7 @@
 using Common;
 using JetBrains.Annotations;
 using Lykke.Cqrs;
+using Lykke.Snow.Common.Extensions;
 using MarginTrading.AccountsManagement.Contracts.Events;
 using MarginTrading.AccountsManagement.Contracts.Models;
 using MarginTrading.AccountsManagement.Infrastructure;
@@ -42,7 +43,7 @@ namespace MarginTrading.AccountsManagement.Services.Implementation
 
             CqrsEngine.PublishEvent(
                 new AccountChangedEvent(
-                    account.ModificationTimestamp,
+                    account.ModificationTimestamp.AssumeUtcIfUnspecified(),
                     source,
                     _convertService.Convert<IAccount, AccountContract>(account),
                     eventType,

--- a/tests/MarginTrading.AccountsManagement.Tests/Extensions/DateTimeExtensionsTests.cs
+++ b/tests/MarginTrading.AccountsManagement.Tests/Extensions/DateTimeExtensionsTests.cs
@@ -2,9 +2,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using MarginTrading.AccountsManagement.Extensions;
+using MarginTrading.AccountsManagement.Repositories.Implementation.SQL;
 using MarginTrading.AccountsManagement.Tests.Helpers;
 using NUnit.Framework;
 
@@ -12,6 +15,17 @@ namespace MarginTrading.AccountsManagement.Tests.Extensions
 {
     public class DateTimeExtensionsTests
     {
+        private static object[] AccountsTestData = new object[]
+        {
+            new List<AccountEntity>() 
+            {
+                new AccountEntity() { ModificationTimestamp = DateTime.UtcNow.AddDays(-5), LastUpdatedAt = DateTime.UtcNow },
+                new AccountEntity() { ModificationTimestamp = DateTime.UtcNow.AddDays(2), LastUpdatedAt = DateTime.UtcNow },
+                new AccountEntity() { ModificationTimestamp = new DateTime(2023, 01, 20, 10, 0, 0), LastUpdatedAt = new DateTime(2023, 01, 20, 10, 11, 0)},
+                new AccountEntity() { ModificationTimestamp = new DateTime(2023, 01, 20, 10, 1, 0), LastUpdatedAt = new DateTime(2023, 01, 20, 10, 0, 0)}
+            }
+        };
+
         private FakeLocalTimeZone _fakeLocalTimeZone; 
         
         [SetUp]
@@ -75,6 +89,50 @@ namespace MarginTrading.AccountsManagement.Tests.Extensions
             result.Kind.Should().Be(DateTimeKind.Utc);
             offset.Should().NotBe(TimeSpan.Zero); // only for testing purposes
             result.Should().Be(date.Add(-offset));
+        }
+
+        [Test]
+        [TestCase("2023-01-18T10:00:00+0000", "2023-01-18T11:00:00+0000", "2023-01-18T11:00:00+0000")]
+        [TestCase("2023-01-19T10:00:00+0000", "2023-01-18T11:00:00+0000", "2023-01-19T10:00:00+0000")]
+        [TestCase("2023-01-18T10:29:00+0000", "2023-01-18T10:31:00+0000", "2023-01-18T10:31:00+0000")]
+        [TestCase("2023-01-19T10:42:00+0000", "2023-01-19T10:39:00+0000", "2023-01-19T10:42:00+0000")]
+        [TestCase("2023-01-20T10:00:00+0300", "2023-01-20T11:00:00+0500", "2023-01-20T10:00:00+0300")]
+        [TestCase("2023-01-20T11:30:00+0300", "2023-01-20T13:29:00+0500", "2023-01-20T11:30:00+0300")]
+        public void MaxDateTimeFunction_ShouldReturnTheMostRecentDateTime(string timestamp1, string timestamp2, string expected)
+        {
+            var dt1 = DateTime.Parse(timestamp1);
+            var dt2 = DateTime.Parse(timestamp2);
+
+            var result = DateTimeExtensions.MaxDateTime(dt1, dt2);
+
+            Assert.AreEqual(DateTime.Parse(expected), result);
+        }
+
+        [Test]
+        [TestCaseSource(nameof(AccountsTestData))]
+        public void OverwriteTimestampWithMostRecent_ShouldPickupTheMostRecentTimestamp(IEnumerable<AccountEntity> accounts)
+        {
+            // Arrange
+            Action<AccountEntity, DateTime> fnUpdateDateTimeProperty = (account, mostRecent) => account.ModificationTimestamp = mostRecent;
+
+            // Act
+            DateTimeExtensions.OverwriteTimestampWithMostRecent(accounts, 
+                getFirstTimeStamp: (a) => a.LastUpdatedAt,
+                getSecondTimestamp: (a) => a.ModificationTimestamp,
+                updateProperty: fnUpdateDateTimeProperty);
+
+            // Assert
+            foreach(var account in accounts)
+            {
+                DateTime greater = default(DateTime);
+
+                if (account.ModificationTimestamp >= account.LastUpdatedAt)
+                    greater = account.ModificationTimestamp;
+                else
+                    greater = account.LastUpdatedAt;
+
+                Assert.AreEqual(greater, account.ModificationTimestamp);
+            }
         }
     }
 }


### PR DESCRIPTION
[LT-4383](https://lykke-snow.atlassian.net/browse/LT-4383)

~~It turns out that the **ModificationTimeStamp** does not get updated after updating clients' **ClientProfile**.  This situation causes issues with cached account data.~~

~~This PR introduces changes to update clients' all accounts upon updating ClientProfile.~~

[LT-4383]: https://lykke-snow.atlassian.net/browse/LT-4383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

1. Introduce a new column in **MarginTradingClients** table, also the **ClientEntity** class named **LastUpdatedAt**
2. Update **LastUpdatedAt** with current UTC time upon updating client's **ClientProfile**
3. For AccountEntity instances **ModificationTimestamp**, return `Max(account.ModificationTimestamp, account.Client.LastUpdatedAt)`