### PR TITLE
fix(LT-4517): Add currency field to the event payloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -453,3 +453,9 @@ $RECYCLE.BIN/
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+## Environment specific appsettings
+appsettings.localhost.json
+appsettings.dev.json
+appsettings.test.json
+appsettings.prod.json

--- a/src/MarginTrading.AccountsManagement.Contracts/Events/DepositFailedEvent.cs
+++ b/src/MarginTrading.AccountsManagement.Contracts/Events/DepositFailedEvent.cs
@@ -13,9 +13,25 @@ namespace MarginTrading.AccountsManagement.Contracts.Events
     [MessagePackObject]
     public class DepositFailedEvent : BaseEvent
     {
-        public DepositFailedEvent([NotNull] string operationId, DateTime eventTimestamp) 
-            : base(operationId, eventTimestamp)
+        [Key(2)]
+        public string ClientId { get; }
+
+        [Key(3)]
+        public string AccountId { get; }
+
+        [Key(4)]
+        public decimal Amount { get; }
+
+        [Key(5)]
+        public string Currency { get; }
+
+        public DepositFailedEvent([NotNull] string operationId, DateTime eventTimestamp,
+            string clientId, string accountId, decimal amount, string currency) : base(operationId, eventTimestamp)
         {
+            ClientId = clientId;
+            AccountId = accountId;
+            Amount = amount;
+            Currency = currency;
         }
     }
 }

--- a/src/MarginTrading.AccountsManagement.Contracts/Events/DepositSucceededEvent.cs
+++ b/src/MarginTrading.AccountsManagement.Contracts/Events/DepositSucceededEvent.cs
@@ -19,14 +19,16 @@ namespace MarginTrading.AccountsManagement.Contracts.Events
 
         [Key(4)] public decimal Amount { get; }
 
+        [Key(5)] public string Currency { get; }
+
         public DepositSucceededEvent([NotNull] string operationId, DateTime eventTimestamp, [CanBeNull] string clientId,
-            [NotNull] string accountId, decimal amount)
+            [NotNull] string accountId, [NotNull] decimal amount, string currency)
             : base(operationId, eventTimestamp)
         {
             ClientId = clientId;
             AccountId = accountId ?? throw new ArgumentNullException(nameof(accountId));
             Amount = amount;
-
+            Currency = currency;
         }
     }
 }

--- a/src/MarginTrading.AccountsManagement.Contracts/Events/WithdrawalFailedEvent.cs
+++ b/src/MarginTrading.AccountsManagement.Contracts/Events/WithdrawalFailedEvent.cs
@@ -25,14 +25,18 @@ namespace MarginTrading.AccountsManagement.Contracts.Events
         [Key(5)]
         public decimal Amount { get; }
 
+        [Key(6)]
+        public string Currency { get; }
+
         public WithdrawalFailedEvent([NotNull] string operationId, DateTime eventTimestamp, string reason,
-            string accountId, string clientId, decimal amount)
+            string accountId, string clientId, decimal amount, string currency)
             : base(operationId, eventTimestamp)
         {
             Reason = reason;
             AccountId = accountId;
             ClientId = clientId;
             Amount = amount;
+            Currency = currency;
         }
     }
 }

--- a/src/MarginTrading.AccountsManagement.Contracts/Events/WithdrawalSucceededEvent.cs
+++ b/src/MarginTrading.AccountsManagement.Contracts/Events/WithdrawalSucceededEvent.cs
@@ -22,13 +22,17 @@ namespace MarginTrading.AccountsManagement.Contracts.Events
         [Key(4)] 
         public decimal Amount { get; }
 
+        [Key(5)] 
+        public string Currency { get; }
+
         public WithdrawalSucceededEvent([NotNull] string operationId, DateTime eventTimestamp,
-            [CanBeNull] string clientId, [NotNull] string accountId, decimal amount)
+            [CanBeNull] string clientId, [NotNull] string accountId, decimal amount, string currency)
             : base(operationId, eventTimestamp)
         {
             ClientId = clientId;
             AccountId = accountId ?? throw new ArgumentNullException(nameof(accountId));
             Amount = amount;
+            Currency = currency;
         }
     }
 }

--- a/src/MarginTrading.AccountsManagement/Workflow/Withdrawal/WithdrawalCommandsHandler.cs
+++ b/src/MarginTrading.AccountsManagement/Workflow/Withdrawal/WithdrawalCommandsHandler.cs
@@ -143,7 +143,8 @@ namespace MarginTrading.AccountsManagement.Workflow.Withdrawal
                 command.Reason,
                 executionInfo.Data.AccountId,
                 account?.ClientId,
-                executionInfo.Data.Amount));
+                executionInfo.Data.Amount,
+                currency: account?.BaseAssetId));
         }
 
         /// <summary>
@@ -166,8 +167,13 @@ namespace MarginTrading.AccountsManagement.Workflow.Withdrawal
                 "(OperationId: {OperationId}, AccountId: {AccountId}, Amount: {Amount})",
                 command.OperationId, account.Id, executionInfo.Data.Amount);
 
-            publisher.PublishEvent(new WithdrawalSucceededEvent(command.OperationId, _systemClock.UtcNow.UtcDateTime,
-                account?.ClientId, executionInfo.Data.AccountId, executionInfo.Data.Amount));
+            publisher.PublishEvent(new WithdrawalSucceededEvent(
+                operationId: command.OperationId, 
+                eventTimestamp: _systemClock.UtcNow.UtcDateTime,
+                clientId: account?.ClientId, 
+                accountId: executionInfo.Data.AccountId, 
+                amount: executionInfo.Data.Amount,
+                currency: account?.BaseAssetId));
         }
     }
 }


### PR DESCRIPTION
This PR introduces changes to add 'Currency' field to the following events, to be able to display currency information on push notifications & activities page.

- WithdrawalSucceededEvent
- WithdrawalFailedEvent
- DepositSucceededEvent
- DepositFailedEvent

Also new fields in DepositFailedEvent (which previously had nothing in the payload.)
- ClientId
- AccountId
- Amount
- Currency

