### PR TITLE
Lt 4804 Introduce new event 'AccountTaxHistoryUpdatedEvent'

### DIFF
--- a/src/MarginTrading.AccountsManagement.AccountHistoryBroker/AccountTaxHistoryUpdatedPublisher.cs
+++ b/src/MarginTrading.AccountsManagement.AccountHistoryBroker/AccountTaxHistoryUpdatedPublisher.cs
@@ -1,0 +1,54 @@
+using System.Threading.Tasks;
+
+using Lykke.RabbitMqBroker.Publisher;
+using Lykke.RabbitMqBroker.Publisher.Serializers;
+using Lykke.RabbitMqBroker.Publisher.Strategies;
+
+using MarginTrading.AccountsManagement.Contracts.Events;
+
+using Microsoft.Extensions.Logging;
+
+namespace MarginTrading.AccountsManagement.AccountHistoryBroker
+{
+    public class TaxHistoryInsertedPublisher : IRabbitPublisher<AccountTaxHistoryUpdatedEvent>
+    {
+        private RabbitMqPublisher<AccountTaxHistoryUpdatedEvent> _publisher;
+        private readonly ILoggerFactory _loggerFactory;
+        private readonly Settings _settings;
+
+        public TaxHistoryInsertedPublisher(ILoggerFactory loggerFactory, 
+            Settings settings)
+        {
+            _loggerFactory = loggerFactory;
+            _settings = settings;
+        }
+
+        public async Task PublishAsync(AccountTaxHistoryUpdatedEvent message)
+        {
+            await _publisher.ProduceAsync(message);
+        }
+
+        public void Start()
+        {
+            _publisher = new RabbitMqPublisher<AccountTaxHistoryUpdatedEvent>(
+                _loggerFactory, _settings.RabbitMq.AccountTaxHistoryUpdated)
+                .SetSerializer(new MessagePackMessageSerializer<AccountTaxHistoryUpdatedEvent>())
+                .SetPublishStrategy(new TopicPublishStrategy(_settings.RabbitMq.AccountTaxHistoryUpdated))
+                .DisableInMemoryQueuePersistence()
+                .PublishSynchronously();
+
+            _publisher.Start();
+        }
+
+        public void Dispose() 
+        {
+            _publisher?.Dispose();
+        }
+
+        public void Stop()
+        {
+            _publisher?.Dispose();
+        }
+    }
+}
+ 

--- a/src/MarginTrading.AccountsManagement.AccountHistoryBroker/AccountTaxHistoryUpdatedPublisher.cs
+++ b/src/MarginTrading.AccountsManagement.AccountHistoryBroker/AccountTaxHistoryUpdatedPublisher.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 
 using Lykke.RabbitMqBroker.Publisher;
@@ -33,7 +34,7 @@ namespace MarginTrading.AccountsManagement.AccountHistoryBroker
             _publisher = new RabbitMqPublisher<AccountTaxHistoryUpdatedEvent>(
                 _loggerFactory, _settings.RabbitMq.AccountTaxHistoryUpdated)
                 .SetSerializer(new MessagePackMessageSerializer<AccountTaxHistoryUpdatedEvent>())
-                .SetPublishStrategy(new TopicPublishStrategy(_settings.RabbitMq.AccountTaxHistoryUpdated))
+                .SetPublishStrategy(new PropertiesWithMessageTypeTopicPublishStrategy(_settings.RabbitMq.AccountTaxHistoryUpdated))
                 .DisableInMemoryQueuePersistence()
                 .PublishSynchronously();
 

--- a/src/MarginTrading.AccountsManagement.AccountHistoryBroker/AccountTaxHistoryUpdatedPublisher.cs
+++ b/src/MarginTrading.AccountsManagement.AccountHistoryBroker/AccountTaxHistoryUpdatedPublisher.cs
@@ -1,12 +1,7 @@
-using System;
 using System.Threading.Tasks;
-
 using Lykke.RabbitMqBroker.Publisher;
 using Lykke.RabbitMqBroker.Publisher.Serializers;
-using Lykke.RabbitMqBroker.Publisher.Strategies;
-
 using MarginTrading.AccountsManagement.Contracts.Events;
-
 using Microsoft.Extensions.Logging;
 
 namespace MarginTrading.AccountsManagement.AccountHistoryBroker

--- a/src/MarginTrading.AccountsManagement.AccountHistoryBroker/PropertiesWithMessageTypeTopicPublishStrategy.cs
+++ b/src/MarginTrading.AccountsManagement.AccountHistoryBroker/PropertiesWithMessageTypeTopicPublishStrategy.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+using Lykke.RabbitMqBroker;
+using Lykke.RabbitMqBroker.Publisher;
+using Lykke.RabbitMqBroker.Publisher.Strategies;
+
+using RabbitMQ.Client;
+
+namespace MarginTrading.AccountsManagement.AccountHistoryBroker
+{
+    public sealed class PropertiesWithMessageTypeTopicPublishStrategy : IRabbitMqPublishStrategy
+    {
+        private readonly bool _durable;
+        private readonly string _routingKey;
+        private readonly string _exchangeName;
+
+        public PropertiesWithMessageTypeTopicPublishStrategy(RabbitMqSubscriptionSettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            _routingKey = settings.RoutingKey ?? string.Empty;
+            _durable = settings.IsDurable;
+            _exchangeName = settings.ExchangeName;
+        }
+
+        public void Configure(IModel channel)
+        {
+            channel.ExchangeDeclare(_exchangeName, "topic", _durable);
+        }
+
+        public void Publish(IModel channel, RawMessage message)
+        {
+            IBasicProperties properties = channel.CreateBasicProperties();
+            properties.DeliveryMode = 2;
+            properties.Type = _routingKey;
+            var headers = message.Headers ?? new Dictionary<string, object>();
+            headers.Add("initialRoute", string.Format(CultureInfo.InvariantCulture, @"topic://{0}/{1}", _exchangeName, _routingKey));
+            properties.Headers = new Dictionary<string, object>(headers);
+
+            channel.BasicPublish(
+                _exchangeName,
+                message.RoutingKey ?? _routingKey,
+                properties,
+                message.Body);
+        }
+    }
+}

--- a/src/MarginTrading.AccountsManagement.AccountHistoryBroker/Settings.cs
+++ b/src/MarginTrading.AccountsManagement.AccountHistoryBroker/Settings.cs
@@ -3,6 +3,7 @@
 
 using JetBrains.Annotations;
 using Lykke.MarginTrading.BrokerBase.Settings;
+using Lykke.RabbitMqBroker;
 using Lykke.SettingsReader.Attributes;
 
 namespace MarginTrading.AccountsManagement.AccountHistoryBroker
@@ -15,6 +16,7 @@ namespace MarginTrading.AccountsManagement.AccountHistoryBroker
         public RabbitMqQueues RabbitMqQueues { get; set; }
 
         public ServiceSettings AccountManagement { get; set; }
+        public RabbitMqSettings RabbitMq { get; set; }
     }
     
     [UsedImplicitly]
@@ -44,5 +46,40 @@ namespace MarginTrading.AccountsManagement.AccountHistoryBroker
 
         [Optional]
         public string ApiKey { get; set; }
+    }
+
+    public class RabbitMqSettings
+    {
+        public SubscriptionSettings AccountTaxHistoryUpdated { get; set; }
+    }
+
+    public class SubscriptionSettings
+    {
+        [Optional]
+        public string RoutingKey { get; set; }
+        [Optional]
+        public bool IsDurable { get; set; }
+
+        public string ExchangeName { get; set; }
+
+        [Optional]
+        public string QueueName { get; set; }
+
+        public string ConnectionString { get; set; }
+        
+        [Optional]
+        public int NumberOfConsumers { get; set; } = 1;
+
+        public static implicit operator RabbitMqSubscriptionSettings(SubscriptionSettings subscriptionSettings)
+        {
+            return new RabbitMqSubscriptionSettings()
+            {
+                RoutingKey = subscriptionSettings.RoutingKey,
+                IsDurable = subscriptionSettings.IsDurable,
+                ExchangeName = subscriptionSettings.ExchangeName,
+                QueueName = subscriptionSettings.QueueName,
+                ConnectionString = subscriptionSettings.ConnectionString
+            };
+        }
     }
 }

--- a/src/MarginTrading.AccountsManagement.AccountHistoryBroker/Startup.cs
+++ b/src/MarginTrading.AccountsManagement.AccountHistoryBroker/Startup.cs
@@ -15,6 +15,15 @@ using MarginTrading.AccountsManagement.Contracts;
 using Microsoft.Extensions.Configuration;
 using SqlRepos = MarginTrading.AccountsManagement.AccountHistoryBroker.Repositories.SqlRepositories;
 using Microsoft.Extensions.Hosting;
+using Common;
+using Microsoft.Extensions.Logging;
+using Lykke.Snow.Common.Correlation.RabbitMq;
+using Lykke.RabbitMqBroker;
+using Lykke.RabbitMqBroker.Publisher.Serializers;
+using Lykke.RabbitMqBroker.Publisher;
+using Lykke.RabbitMqBroker.Publisher.Strategies;
+using Common.Log;
+using MarginTrading.AccountsManagement.Contracts.Commands;
 
 namespace MarginTrading.AccountsManagement.AccountHistoryBroker
 {
@@ -49,6 +58,34 @@ namespace MarginTrading.AccountsManagement.AccountHistoryBroker
             {
                 throw new InvalidOperationException("Azure storage mode is not supported");
             }
+
+            builder.RegisterType<TaxHistoryInsertedPublisher>();
         }
+        
+        // TODO: remove
+        // private static Lykke.RabbitMqBroker.Publisher.IMessageProducer<TMessage> GetProducer<TMessage>(
+        //    ILoggerFactory loggerFactory,
+        //    RabbitMqCorrelationManager correlationManager,
+        //    RabbitMqSubscriptionSettings settings,
+        //    IRabbitMqSerializer<TMessage> serializer, ILog logger, IRabbitMqPublishStrategy publishStrategy,
+        //    IApplicationLifetime applicationLifetime,
+        //    IPublishingQueueRepository publishingQueueRepository = null)
+        // {
+        //    var publisher = new RabbitMqPublisher<TMessage>(loggerFactory, settings);
+
+        //    if (settings.IsDurable && publishingQueueRepository != null)
+        //        publisher.SetQueueRepository(publishingQueueRepository);
+        //    else
+        //        publisher.DisableInMemoryQueuePersistence();
+        //        
+        //    applicationLifetime.ApplicationStopping.Register(obj => ((IDisposable)obj).Dispose(), publisher);
+
+        //    var result = publisher
+        //        .SetSerializer(serializer)
+        //        .SetPublishStrategy(publishStrategy)
+        //        .SetWriteHeadersFunc(correlationManager.BuildCorrelationHeadersIfExists);
+        //    result.Start();
+        //    return result;
+        // }
     }
 }

--- a/src/MarginTrading.AccountsManagement.AccountHistoryBroker/Startup.cs
+++ b/src/MarginTrading.AccountsManagement.AccountHistoryBroker/Startup.cs
@@ -15,15 +15,6 @@ using MarginTrading.AccountsManagement.Contracts;
 using Microsoft.Extensions.Configuration;
 using SqlRepos = MarginTrading.AccountsManagement.AccountHistoryBroker.Repositories.SqlRepositories;
 using Microsoft.Extensions.Hosting;
-using Common;
-using Microsoft.Extensions.Logging;
-using Lykke.Snow.Common.Correlation.RabbitMq;
-using Lykke.RabbitMqBroker;
-using Lykke.RabbitMqBroker.Publisher.Serializers;
-using Lykke.RabbitMqBroker.Publisher;
-using Lykke.RabbitMqBroker.Publisher.Strategies;
-using Common.Log;
-using MarginTrading.AccountsManagement.Contracts.Commands;
 
 namespace MarginTrading.AccountsManagement.AccountHistoryBroker
 {
@@ -61,31 +52,5 @@ namespace MarginTrading.AccountsManagement.AccountHistoryBroker
 
             builder.RegisterType<TaxHistoryInsertedPublisher>();
         }
-        
-        // TODO: remove
-        // private static Lykke.RabbitMqBroker.Publisher.IMessageProducer<TMessage> GetProducer<TMessage>(
-        //    ILoggerFactory loggerFactory,
-        //    RabbitMqCorrelationManager correlationManager,
-        //    RabbitMqSubscriptionSettings settings,
-        //    IRabbitMqSerializer<TMessage> serializer, ILog logger, IRabbitMqPublishStrategy publishStrategy,
-        //    IApplicationLifetime applicationLifetime,
-        //    IPublishingQueueRepository publishingQueueRepository = null)
-        // {
-        //    var publisher = new RabbitMqPublisher<TMessage>(loggerFactory, settings);
-
-        //    if (settings.IsDurable && publishingQueueRepository != null)
-        //        publisher.SetQueueRepository(publishingQueueRepository);
-        //    else
-        //        publisher.DisableInMemoryQueuePersistence();
-        //        
-        //    applicationLifetime.ApplicationStopping.Register(obj => ((IDisposable)obj).Dispose(), publisher);
-
-        //    var result = publisher
-        //        .SetSerializer(serializer)
-        //        .SetPublishStrategy(publishStrategy)
-        //        .SetWriteHeadersFunc(correlationManager.BuildCorrelationHeadersIfExists);
-        //    result.Start();
-        //    return result;
-        // }
     }
 }

--- a/src/MarginTrading.AccountsManagement.Contracts/Events/AccountTaxHistoryUpdatedEvent.cs
+++ b/src/MarginTrading.AccountsManagement.Contracts/Events/AccountTaxHistoryUpdatedEvent.cs
@@ -1,0 +1,41 @@
+using System;
+using JetBrains.Annotations;
+using MarginTrading.AccountsManagement.Contracts.Models;
+using MessagePack;
+
+namespace MarginTrading.AccountsManagement.Contracts.Events
+{
+    /// <summary>
+    /// Indicates that a recent tax transaction has been inserted to the account history.
+    /// </summary>
+    [MessagePackObject]
+    public class AccountTaxHistoryUpdatedEvent
+    {
+        /// <summary>
+        /// Operation Id - used as correlation id
+        /// </summary>
+        [Key(0)]
+        public string OperationId { get; }
+
+        /// <summary>
+        /// Date and time of event
+        /// </summary>
+        [Key(1)]
+        public DateTime ChangeTimestamp { get; }
+
+        /// <summary>
+        /// Account snapshot at the moment immediately after the event happened
+        /// </summary>
+        [NotNull]
+        [Key(2)]
+        public AccountContract Account { get; }
+
+        public AccountTaxHistoryUpdatedEvent(string operationId, DateTime changeTimestamp, AccountContract account)
+        {
+            OperationId = operationId;
+            ChangeTimestamp = changeTimestamp;
+            Account = account;
+        }
+
+    } 
+}

--- a/src/MarginTrading.AccountsManagement.Contracts/Events/AccountTaxHistoryUpdatedEvent.cs
+++ b/src/MarginTrading.AccountsManagement.Contracts/Events/AccountTaxHistoryUpdatedEvent.cs
@@ -36,6 +36,5 @@ namespace MarginTrading.AccountsManagement.Contracts.Events
             ChangeTimestamp = changeTimestamp;
             Account = account;
         }
-
     } 
 }


### PR DESCRIPTION
This PR introduces a new event 'AccountTaxHistoryUpdatedEvent', to be published upon inserting a new record to `dbo.AccountHistory` table with `Reason = Tax`.

So that we can understand a particular tax has successfully been charged.