### PR TITLE
fix(LT-5009): add option to request for disposable capital with addit…

### DIFF
--- a/src/MarginTrading.AccountsManagement.Contracts/Api/GetDisposableCapitalRequest.cs
+++ b/src/MarginTrading.AccountsManagement.Contracts/Api/GetDisposableCapitalRequest.cs
@@ -1,0 +1,44 @@
+// Copyright (c) 2019 Lykke Corp.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+using JetBrains.Annotations;
+
+namespace MarginTrading.AccountsManagement.Contracts.Api
+{
+    /// <summary>
+    /// Get disposable capital request details
+    /// </summary>
+    public class GetDisposableCapitalRequest
+    {
+        public class AccountCapitalFigures
+        {
+            public decimal Balance { get; set; }
+            public DateTime LastBalanceChangeTime { get; set; }
+            public decimal TotalCapital { get; set; }
+            public decimal FreeMargin { get; set; }
+            public decimal UsedMargin { get; set; }
+            public decimal CurrentlyUsedMargin { get; set; }
+            public decimal InitiallyUsedMargin { get; set; }
+            public decimal PnL { get; set; }
+            public decimal UnrealizedDailyPnl { get; set; }
+            public int OpenPositionsCount { get; set; }
+            public string AdditionalInfo { get; set; }
+            public decimal TodayRealizedPnL { get; set; }
+            public decimal TodayUnrealizedPnL { get; set; }
+            public decimal TodayDepositAmount { get; set; }
+            public decimal TodayWithdrawAmount { get; set; }
+            public decimal TodayCommissionAmount { get; set; }
+            public decimal TodayOtherAmount { get; set; }
+            public decimal TodayStartBalance { get; set; }
+            public bool AccountIsDeleted { get; set; }
+        }
+        
+        /// <summary>
+        /// Optional capital figures for account.
+        /// Can be used if caller, typically, trading core, has this information already.
+        /// </summary>
+        [CanBeNull] public AccountCapitalFigures CapitalFigures { get; set; }
+    }
+}

--- a/src/MarginTrading.AccountsManagement.Contracts/Api/GetDisposableCapitalRequest.cs
+++ b/src/MarginTrading.AccountsManagement.Contracts/Api/GetDisposableCapitalRequest.cs
@@ -33,6 +33,7 @@ namespace MarginTrading.AccountsManagement.Contracts.Api
             public decimal TodayOtherAmount { get; set; }
             public decimal TodayStartBalance { get; set; }
             public bool AccountIsDeleted { get; set; }
+            public decimal UnconfirmedMargin { get; set; }
         }
         
         /// <summary>

--- a/src/MarginTrading.AccountsManagement.Contracts/IAccountsApi.cs
+++ b/src/MarginTrading.AccountsManagement.Contracts/IAccountsApi.cs
@@ -146,9 +146,12 @@ namespace MarginTrading.AccountsManagement.Contracts
         /// Get account disposable capital for the current trading day
         /// </summary>
         /// <param name="accountId"></param>
+        /// <param name="request">Request details. In particular, capital figures can be optionally provided</param>
         /// <returns></returns>
         [Get("/api/accounts/{accountId}/disposable-capital")]
-        Task<decimal?> GetDisposableCapital(string accountId);
+        Task<decimal?> GetDisposableCapital(
+            string accountId, 
+            [Query] [CanBeNull] GetDisposableCapitalRequest request = null);
 
         [Post("/api/accounts/stat/{accountId}/recalculate")]
         Task RecalculateStat(string accountId);

--- a/src/MarginTrading.AccountsManagement/Controllers/AccountsController.cs
+++ b/src/MarginTrading.AccountsManagement/Controllers/AccountsController.cs
@@ -27,9 +27,11 @@ using Microsoft.Extensions.Internal;
 using Refit;
 using MarginTrading.AccountsManagement.Exceptions;
 using MarginTrading.AccountsManagement.Contracts.ErrorCodes;
+using MarginTrading.AccountsManagement.Filters;
 using MarginTrading.AccountsManagement.Infrastructure.Implementation;
 using MarginTrading.AccountsManagement.InternalModels;
 using MarginTrading.AccountsManagement.InternalModels.ErrorCodes;
+using MarginTrading.AccountsManagement.Services.Implementation;
 
 namespace MarginTrading.AccountsManagement.Controllers
 {
@@ -610,8 +612,6 @@ namespace MarginTrading.AccountsManagement.Controllers
             return Convert(account);
         }
 
-
-
         #endregion System actions
 
         /// <summary>
@@ -633,7 +633,11 @@ namespace MarginTrading.AccountsManagement.Controllers
         }
         
         [HttpGet("{accountId}/disposable-capital")]
-        public async Task<decimal?> GetDisposableCapital(string accountId)
+        [TypeFilter(
+            typeof(PersistModelToContextFilter<GetDisposableCapitalRequest>),
+            Arguments = new object[] { AccountsApiDecorator.HttpContextDisposableCapitalKey })]
+        public async Task<decimal?> GetDisposableCapital(string accountId,
+            [FromQuery] [CanBeNull] GetDisposableCapitalRequest request = null)
         {
             if (string.IsNullOrWhiteSpace(accountId))
             {
@@ -644,7 +648,7 @@ namespace MarginTrading.AccountsManagement.Controllers
 
             return stat?.DisposableCapital;
         }
-        
+
         /// <summary>
         /// Recalculates account statistics
         /// </summary>

--- a/src/MarginTrading.AccountsManagement/Filters/PersistModelToContextFilter.cs
+++ b/src/MarginTrading.AccountsManagement/Filters/PersistModelToContextFilter.cs
@@ -1,0 +1,74 @@
+// Copyright (c) 2019 Lykke Corp.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace MarginTrading.AccountsManagement.Filters
+{
+    /// <summary>
+    /// Saves the parameter of type <typeparamref name="T"/>
+    /// to the HttpContext.Items with the specified key
+    /// </summary>
+    /// <typeparam name="T">
+    /// The type of the parameter. If there are multiple parameters of this type,
+    /// the first one will be used
+    /// </typeparam>
+    /// <exception cref="ArgumentNullException">
+    /// if key is null or whitespace
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// if failed to add the parameter to the HttpContext.Items
+    /// </exception>
+    internal sealed class PersistModelToContextFilter<T> : IActionFilter
+    {
+        private readonly string _key;
+
+        public PersistModelToContextFilter(string key)
+        {
+            if (string.IsNullOrWhiteSpace(key))
+                throw new ArgumentNullException(nameof(key));
+
+            _key = key;
+        }
+
+        public void OnActionExecuting(ActionExecutingContext context)
+        {
+            var model = ExtractFirstOfType<T>(context.ActionArguments.Values);
+            
+            if (model == null)
+                return;
+            
+            if (!TryPersist(context.HttpContext.Items, _key, model))
+                throw new InvalidOperationException($"Failed to add {nameof(model)} to HttpContext with key {_key}");
+        }
+
+        public void OnActionExecuted(ActionExecutedContext context)
+        {
+        }
+
+        public static TValue ExtractFirstOfType<TValue>(ICollection<object> source)
+        {
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+
+            var results = source.OfType<TValue>();
+            
+            return results.FirstOrDefault();
+        }
+
+        public static bool TryPersist<TValue>(IDictionary<object, object> store, string key, TValue model)
+        {
+            if (store == null)
+                throw new ArgumentNullException(nameof(store));
+
+            if (string.IsNullOrWhiteSpace(key))
+                throw new ArgumentNullException(nameof(key));
+
+            return store.TryAdd(key, model);
+        }
+    }
+}

--- a/src/MarginTrading.AccountsManagement/Infrastructure/Implementation/ConvertService.cs
+++ b/src/MarginTrading.AccountsManagement/Infrastructure/Implementation/ConvertService.cs
@@ -7,14 +7,20 @@ using System.Linq;
 using AutoMapper;
 using JetBrains.Annotations;
 using Lykke.Snow.Common.Extensions;
+
+using MarginTrading.AccountsManagement.Contracts.Api;
 using MarginTrading.AccountsManagement.Contracts.Audit;
 using MarginTrading.AccountsManagement.Contracts.Models;
 using MarginTrading.AccountsManagement.Contracts.Models.AdditionalInfo;
 using MarginTrading.AccountsManagement.InternalModels;
 using MarginTrading.AccountsManagement.InternalModels.Interfaces;
 using MarginTrading.AccountsManagement.Repositories.Implementation.SQL;
+using MarginTrading.Backend.Contracts.Account;
 
 using Newtonsoft.Json;
+
+using AccountBalanceChangeReasonType = MarginTrading.AccountsManagement.InternalModels.AccountBalanceChangeReasonType;
+using AccountStatContract = MarginTrading.AccountsManagement.Contracts.Models.AccountStatContract;
 
 namespace MarginTrading.AccountsManagement.Infrastructure.Implementation
 {
@@ -56,6 +62,8 @@ namespace MarginTrading.AccountsManagement.Infrastructure.Implementation
                 //Audit
                 cfg.CreateMap<AuditModel, AuditContract>();
                 cfg.CreateMap<GetAuditLogsRequest, AuditLogsFilterDto>();
+
+                cfg.CreateMap<GetDisposableCapitalRequest.AccountCapitalFigures, AccountCapitalFigures>();
             }).CreateMapper();
         }
 

--- a/src/MarginTrading.AccountsManagement/Modules/AccountsManagementExternalServicesModule.cs
+++ b/src/MarginTrading.AccountsManagement/Modules/AccountsManagementExternalServicesModule.cs
@@ -2,22 +2,19 @@
 // See the LICENSE file in the project root for more information.
 
 using Autofac;
-using Autofac.Extensions.DependencyInjection;
-using Lykke.HttpClientGenerator;
+
 using Lykke.SettingsReader;
 using Lykke.Snow.Mdm.Contracts.Api;
-using MarginTrading.AccountsManagement.Infrastructure;
+
 using MarginTrading.AccountsManagement.Settings;
 using MarginTrading.Backend.Contracts;
 using MarginTrading.AssetService.Contracts;
 using MarginTrading.TradingHistory.Client;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace MarginTrading.AccountsManagement.Modules
 {
     internal class AccountsManagementExternalServicesModule : Module
     {
-        private readonly IServiceCollection _services = new ServiceCollection();
         private readonly IReloadingManager<AppSettings> _settings;
 
         public AccountsManagementExternalServicesModule(IReloadingManager<AppSettings> settings)
@@ -27,52 +24,42 @@ namespace MarginTrading.AccountsManagement.Modules
 
         protected override void Load(ContainerBuilder builder)
         {
-            var settingsClientGeneratorBuilder = HttpClientGenerator
-                .BuildForUrl(_settings.CurrentValue.MarginTradingSettingsServiceClient.ServiceUrl)
-                .WithServiceName<LykkeErrorResponse>(
-                    $"MT Settings [{_settings.CurrentValue.MarginTradingSettingsServiceClient.ServiceUrl}]");
-            
-            if (!string.IsNullOrWhiteSpace(_settings.CurrentValue.MarginTradingSettingsServiceClient.ApiKey))
-            {
-                settingsClientGeneratorBuilder = settingsClientGeneratorBuilder
-                    .WithApiKey(_settings.CurrentValue.MarginTradingSettingsServiceClient.ApiKey);
-            }
-
-            var settingsClientGenerator = settingsClientGeneratorBuilder.Create();
+            # region Asset Service Clients
+            var settingsClientGenerator = HttpClientGeneratorFactory.Create(
+                "MT Settings",
+                _settings.CurrentValue.MarginTradingSettingsServiceClient);
 
             builder.RegisterInstance(settingsClientGenerator.Generate<IAssetsApi>());
             builder.RegisterInstance(settingsClientGenerator.Generate<ITradingConditionsApi>());
             builder.RegisterInstance(settingsClientGenerator.Generate<ITradingInstrumentsApi>());
             builder.RegisterInstance(settingsClientGenerator.Generate<IScheduleSettingsApi>());
+            # endregion
 
-            var mtCoreClientGenerator = HttpClientGenerator
-                .BuildForUrl(_settings.CurrentValue.MtBackendServiceClient.ServiceUrl)
-                .WithApiKey(_settings.CurrentValue.MtBackendServiceClient.ApiKey)
-                .WithServiceName<LykkeErrorResponse>(
-                    $"MT Trading Core [{_settings.CurrentValue.MtBackendServiceClient.ServiceUrl}]")
-                .Create();
+            # region Trading Core Clients
+            var mtCoreClientGenerator = HttpClientGeneratorFactory.Create(
+                "MT Trading Core", 
+                _settings.CurrentValue.MtBackendServiceClient);
 
             builder.RegisterInstance(mtCoreClientGenerator.Generate<IOrdersApi>());
             builder.RegisterInstance(mtCoreClientGenerator.Generate<IPositionsApi>());
-            builder.RegisterInstance(mtCoreClientGenerator.Generate<IAccountsApi>());
+            // <see cref="IAccountsApi"/> is decorated with <see cref="AccountsApiHttpContextDecorator"/>
+            // and registered in <see cref="DependencyInjectionSetup" with ASP.NET Core DI container/>
+            # endregion
             
-            var mtTradingHistoryClientGenerator = HttpClientGenerator
-                .BuildForUrl(_settings.CurrentValue.TradingHistoryClient.ServiceUrl)
-                .WithServiceName<LykkeErrorResponse>("MT Core History Service")
-                .WithOptionalApiKey(_settings.CurrentValue.TradingHistoryClient.ApiKey)
-                .Create();
+            # region Trading History Clients
+            var mtTradingHistoryClientGenerator = HttpClientGeneratorFactory.Create(
+                "MT Core History Service",
+                _settings.CurrentValue.TradingHistoryClient);
 
             builder.RegisterInstance(mtTradingHistoryClientGenerator.Generate<IDealsApi>());
+            # endregion
 
-            var mdmClientGenerator = HttpClientGenerator
-                .BuildForUrl(_settings.CurrentValue.MdmServiceClient.ServiceUrl)
-                .WithServiceName<LykkeErrorResponse>("Mdm Service")
-                .WithOptionalApiKey(_settings.CurrentValue.MdmServiceClient.ApiKey)
-                .Create();
+            # region Mdm Service Clients
+            var mdmClientGenerator =
+                HttpClientGeneratorFactory.Create("Mdm Service", _settings.CurrentValue.MdmServiceClient);
 
             builder.RegisterInstance(mdmClientGenerator.Generate<IBrokerSettingsApi>());
-
-            builder.Populate(_services);
+            # endregion
         }
     }
 }

--- a/src/MarginTrading.AccountsManagement/Modules/HttpClientGeneratorFactory.cs
+++ b/src/MarginTrading.AccountsManagement/Modules/HttpClientGeneratorFactory.cs
@@ -1,0 +1,60 @@
+// Copyright (c) 2019 Lykke Corp.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+using Lykke.HttpClientGenerator;
+
+using MarginTrading.AccountsManagement.Infrastructure;
+using MarginTrading.AccountsManagement.Settings;
+
+namespace MarginTrading.AccountsManagement.Modules
+{
+    internal static class HttpClientGeneratorFactory
+    {
+        static HttpClientGeneratorBuilder CreateBuilder(string serviceName, 
+            OptionalClientSettings optionalClientSettings)
+        {
+            return CreateBuilder(serviceName,
+                new ClientSettings
+                {
+                    ApiKey = optionalClientSettings.ApiKey, ServiceUrl = optionalClientSettings.ServiceUrl
+                });
+        }
+        
+        static HttpClientGeneratorBuilder CreateBuilder(string serviceName, ClientSettings clientSettings)
+        {
+            if (clientSettings == null)
+                throw new ArgumentNullException(nameof(clientSettings));
+            
+            if (string.IsNullOrWhiteSpace(serviceName))
+                throw new ArgumentNullException(nameof(serviceName));
+
+            var builder = HttpClientGenerator
+                .BuildForUrl(clientSettings.ServiceUrl)
+                .WithOptionalApiKey(clientSettings.ApiKey)
+                .WithServiceName<LykkeErrorResponse>(
+                    $"{serviceName} [{clientSettings.ServiceUrl}]");
+            
+            return builder;
+        }
+
+        /// <summary>
+        /// Create HttpClientGenerator for specified service name and client settings
+        /// </summary>
+        /// <param name="serviceName"></param>
+        /// <param name="clientSettings"></param>
+        /// <returns></returns>
+        public static HttpClientGenerator Create(string serviceName, ClientSettings clientSettings) =>
+            CreateBuilder(serviceName, clientSettings).Create();
+
+        /// <summary>
+        /// Create HttpClientGenerator for specified service name and optional client settings
+        /// </summary>
+        /// <param name="serviceName"></param>
+        /// <param name="optionalClientSettings"></param>
+        /// <returns></returns>
+        public static HttpClientGenerator Create(string serviceName, OptionalClientSettings optionalClientSettings) =>
+            CreateBuilder(serviceName, optionalClientSettings).Create();
+    }
+}

--- a/src/MarginTrading.AccountsManagement/Services/Implementation/AccountsApiDecorator.cs
+++ b/src/MarginTrading.AccountsManagement/Services/Implementation/AccountsApiDecorator.cs
@@ -1,0 +1,119 @@
+// Copyright (c) 2019 Lykke Corp.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using MarginTrading.AccountsManagement.Contracts.Api;
+using MarginTrading.AccountsManagement.Infrastructure;
+using MarginTrading.Backend.Contracts;
+using MarginTrading.Backend.Contracts.Account;
+using MarginTrading.Backend.Contracts.Common;
+
+using Microsoft.AspNetCore.Http;
+
+namespace MarginTrading.AccountsManagement.Services.Implementation
+{
+    /// <summary>
+    /// Decorator for <see cref="IAccountsApi"/> that provides data
+    /// from HttpContext items if they are present 
+    /// </summary>
+    public sealed class AccountsApiDecorator : IAccountsApi
+    {
+        private readonly IAccountsApi _decoratee;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IConvertService _convertService;
+
+        public const string HttpContextDisposableCapitalKey = "disposable-capital-figures";
+
+        public AccountsApiDecorator(
+            IAccountsApi decoratee,
+            IHttpContextAccessor httpContextAccessor,
+            IConvertService convertService)
+        {
+            _decoratee = decoratee ?? throw new ArgumentNullException(nameof(decoratee));
+            _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
+            _convertService = convertService ?? throw new ArgumentNullException(nameof(convertService));
+        }
+
+        public Task<List<AccountStatContract>> GetAllAccountStats()
+        {
+            return _decoratee.GetAllAccountStats();
+        }
+
+        public Task<PaginatedResponseContract<AccountStatContract>> GetAllAccountStatsByPages(int? skip = null,
+            int? take = null)
+        {
+            return _decoratee.GetAllAccountStatsByPages(skip, take);
+        }
+
+        public Task<List<string>> GetAllAccountIdsFiltered(ActiveAccountsRequest request)
+        {
+            return _decoratee.GetAllAccountIdsFiltered(request);
+        }
+
+        public Task<AccountStatContract> GetAccountStats(string accountId)
+        {
+            return _decoratee.GetAccountStats(accountId);
+        }
+
+        /// <summary>
+        /// Take capital figures from HttpContext.Items first if they are present.
+        /// </summary>
+        /// <param name="accountId"></param>
+        /// <returns></returns>
+        public Task<AccountCapitalFigures> GetCapitalFigures(string accountId)
+        {
+            if (_httpContextAccessor.HttpContext == null)
+                return _decoratee.GetCapitalFigures(accountId);
+
+            var getDisposableCapitalRequest = ExtractOfType<GetDisposableCapitalRequest>(
+                _httpContextAccessor.HttpContext.Items,
+                HttpContextDisposableCapitalKey);
+
+            if (getDisposableCapitalRequest?.CapitalFigures == null)
+                return _decoratee.GetCapitalFigures(accountId);
+
+            var accountCapitalFigures = _convertService.Convert<AccountCapitalFigures>(
+                getDisposableCapitalRequest.CapitalFigures);
+            return Task.FromResult(accountCapitalFigures);
+        }
+
+        public Task ResumeLiquidation(string accountId, string comment)
+        {
+            return _decoratee.ResumeLiquidation(accountId, comment);
+        }
+        
+        /// <summary>
+        /// Extracts value from dictionary by key and tries to cast it to a type <typeparamref name="T"/>
+        /// </summary>
+        /// <param name="source"></param>
+        /// <param name="key"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="InvalidCastException">
+        /// if value cannot be cast to a type <typeparamref name="T"/>
+        /// </exception>
+        public static T ExtractOfType<T>(IDictionary<object, object> source, string key)
+        {
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+
+            if (source.Count == 0)
+                return default;
+            
+            if (string.IsNullOrWhiteSpace(key))
+                throw new ArgumentNullException(nameof(key));
+
+            if (!source.TryGetValue(key, out var value))
+                return default;
+
+            if (value is T result)
+                return result;
+
+            throw new InvalidCastException($"Failed to cast value to a type {typeof(T).Name}");
+        }
+    }
+}

--- a/tests/MarginTrading.AccountsManagement.Tests/AccountsApiDecoratorTests.cs
+++ b/tests/MarginTrading.AccountsManagement.Tests/AccountsApiDecoratorTests.cs
@@ -1,0 +1,71 @@
+// Copyright (c) 2019 Lykke Corp.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+using MarginTrading.AccountsManagement.Services.Implementation;
+
+using NUnit.Framework;
+
+namespace MarginTrading.AccountsManagement.Tests
+{
+    public sealed class AccountsApiDecoratorTests
+    {
+        [Test]
+        public void ExtractOfType_When_NullInput_RaisesException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                AccountsApiDecorator.ExtractOfType<object>(null, "key"));
+        }
+
+        [Test]
+        public void ExtractOfType_When_EmptyInput_ReturnsDefault()
+        {
+            var result = AccountsApiDecorator.ExtractOfType<object>(new Dictionary<object, object>(), "key");
+            Assert.AreEqual(default, result);
+        }
+        
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase(" ")]
+        public void ExtractOfType_When_KeyIsInvalid_RaisesException(string invalidKey)
+        {
+            var nonEmptyDictionary = new Dictionary<object, object> { { "1", new object() } };
+            
+            Assert.Throws<ArgumentNullException>(() =>
+                AccountsApiDecorator.ExtractOfType<object>(nonEmptyDictionary, invalidKey));
+        }
+        
+        [Test]
+        public void ExtractOfType_When_NoKeyPresent_ReturnsDefault()
+        {
+            var nonEmptyDictionary = new Dictionary<object, object> { { "1", new object() } };
+            
+            var result = AccountsApiDecorator.ExtractOfType<object>(nonEmptyDictionary, "2");
+            
+            Assert.AreEqual(default, result);
+        }
+        
+        [Test]
+        public void ExtractOfType_When_KeyPresentButValueIsOfDifferentType_RaisesException()
+        {
+            var nonEmptyDictionary = new Dictionary<object, object> { { "1", new object() } };
+
+            Assert.Throws<InvalidCastException>(() =>
+                AccountsApiDecorator.ExtractOfType<string>(nonEmptyDictionary, "1"));
+        }
+        
+        [Test]
+        public void ExtractOfType_When_KeyPresent_ReturnsValue()
+        {
+            var expected = new object();
+            var nonEmptyDictionary = new Dictionary<object, object> { { "1", expected } };
+
+            var result = AccountsApiDecorator.ExtractOfType<object>(nonEmptyDictionary, "1");
+            
+            Assert.AreEqual(expected, result);
+        }
+    }
+}

--- a/tests/MarginTrading.AccountsManagement.Tests/PersistModelToContextFilterTests.cs
+++ b/tests/MarginTrading.AccountsManagement.Tests/PersistModelToContextFilterTests.cs
@@ -1,0 +1,94 @@
+// Copyright (c) 2019 Lykke Corp.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+using MarginTrading.AccountsManagement.Filters;
+
+using NUnit.Framework;
+
+namespace MarginTrading.AccountsManagement.Tests
+{
+    public sealed class PersistModelToContextFilterTests
+    {
+        [Test]
+        public void ExtractFirstOfType_When_NullInput_RaisesException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                PersistModelToContextFilter<object>.ExtractFirstOfType<object>(null));
+        }
+        
+        [Test]
+        public void ExtractFirstOfType_When_EmptyInput_ReturnsDefault()
+        {
+            var result = PersistModelToContextFilter<object>.ExtractFirstOfType<object>(Array.Empty<object>());
+            Assert.AreEqual(default, result);
+        }
+        
+        [Test]
+        public void ExtractOfType_When_NoValueOfTypePreset_ReturnsDefault()
+        {
+            var result = PersistModelToContextFilter<decimal>.ExtractFirstOfType<decimal>(
+                    new object[] { 1, "not an object type" });
+            Assert.AreEqual(default(decimal), result);
+        }
+        
+        [Test]
+        [Repeat(10)]
+        public void ExtractOfType_When_MultipleValuesOfTypePresent_ReturnsFirst()
+        {
+            var result = PersistModelToContextFilter<int>.ExtractFirstOfType<int>(
+                new object[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 });
+            Assert.AreEqual(1, result);
+        }
+        
+        [Test]
+        public void TryPersist_When_StoreIsNull_RaisesException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                PersistModelToContextFilter<object>.TryPersist(null, "key", new object()));
+        }
+        
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase(" ")]
+        public void TryPersist_When_KeyIsInvalid_RaisesException(string invalidKey)
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                PersistModelToContextFilter<object>.TryPersist(new Dictionary<object, object>(), invalidKey,
+                    new object()));
+        }
+        
+        public void TryPersist_When_Add_Succeeds_ReturnsTrue()
+        {
+            var store = new Dictionary<object, object>();
+            var key = "key";
+            var value = new object();
+            
+            var result = PersistModelToContextFilter<object>.TryPersist(store, key, value);
+            
+            Assert.IsTrue(result);
+            Assert.AreEqual(value, store[key]);
+        }
+        
+        [Test]
+        public void TryPersist_When_Add_Fails_ReturnsFalse()
+        {
+            var store = new Dictionary<object, object>();
+            var key = "key";
+            var value = new object();
+            
+            store.Add(key, value);
+
+            var sameKey = key;
+            var anotherValue = new object();
+            
+            var result = PersistModelToContextFilter<object>.TryPersist(store, sameKey, anotherValue);
+            
+            Assert.IsFalse(result);
+            Assert.AreEqual(1, store.Count);
+        }
+    }
+}


### PR DESCRIPTION
Capital figures can be optionally provided as a part of request,  this will help to decrease http requests when trading core comes to AM and asks for disposable capital since disposable capital calculation requires additional information from trading core.